### PR TITLE
Set specific date and time for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,13 @@ registries:
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
+    allow:
+      - dependency-type: "all"
     schedule:
       interval: "weekly"
+      day: wednesday
+      time: "06:00"
+      timezone: Europe/London
     registries: "*"
     groups:
       gradle-updates:
@@ -33,6 +38,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: wednesday
+      time: "07:00"
+      timezone: Europe/London
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## What

- Set all dependency types for gradle pm using dependabot
- Set a specific day and time for dependabot updates

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
