### PR TITLE
Testing the undeploying of merged/closed PR

### DIFF
--- a/.github/actions/get_merged_release_name/action.yml
+++ b/.github/actions/get_merged_release_name/action.yml
@@ -13,11 +13,16 @@ runs:
   using: "composite"
   steps:
 
+    - name: Get merged branch name
+      shell: bash
+      run: |
+        echo "Merged/closed branch was: ${{ github.event.pull_request.head.ref }}"
+
     - name: Extract merged branch name
       id: extract_branch
       shell: bash
       run: |
-        echo "BRANCH_NAME=$(git log -1 --pretty=%B | grep -oE 'Merge pull request #[0-9]+ from .*/(.*)' | awk '{print $NF}' | sed 's#^[^/]*/##')" >> $GITHUB_OUTPUT
+        echo "${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
 
     - name: Extract release name from branch name
       id: extract_release


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-119)

Trying a different way to get the branch/release name to undeploy that doesn't depend on commit messages.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
