### PR TITLE
Infra/fix uat cleanup

### DIFF
--- a/.github/actions/get_merged_release_name/action.yml
+++ b/.github/actions/get_merged_release_name/action.yml
@@ -1,5 +1,5 @@
 name: "Get merged release name"
-description: 'Get a release name that has just been merged into Main branch'
+description: 'Get the release name for the PR that has just been closed or merged into Main branch'
 
 outputs:
   merged-branch-name:
@@ -13,19 +13,15 @@ runs:
   using: "composite"
   steps:
 
-    - name: Get merged branch name
+    - name: Get branch name for the merged/closed PR
+      id: get_pr_branch
       shell: bash
       run: |
         echo "Merged/closed branch was: ${{ github.event.pull_request.head.ref }}"
-
-    - name: Extract merged branch name
-      id: extract_branch
-      shell: bash
-      run: |
         echo "BRANCH_NAME=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
 
     - name: Extract release name from branch name
       id: extract_release
       uses: ./.github/actions/extract_release_name_from_branch
       with:
-        branch_name: ${{ steps.extract_branch.outputs.branch_name }}
+        branch_name: ${{ steps.get_pr_branch.outputs.branch_name }}

--- a/.github/actions/get_merged_release_name/action.yml
+++ b/.github/actions/get_merged_release_name/action.yml
@@ -22,7 +22,7 @@ runs:
       id: extract_branch
       shell: bash
       run: |
-        echo "${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+        echo "BRANCH_NAME=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
 
     - name: Extract release name from branch name
       id: extract_release

--- a/.github/actions/get_merged_release_name/action.yml
+++ b/.github/actions/get_merged_release_name/action.yml
@@ -13,11 +13,16 @@ runs:
   using: "composite"
   steps:
 
+    - name: Get merged branch name
+      shell: bash
+      run: |
+        echo "Merged/closed branch was: ${{ github.event.pull_request.head.ref }}"
+
     - name: Extract merged branch name
       id: extract_branch
       shell: bash
       run: |
-        echo "BRANCH_NAME=$(git log -1 --pretty=%B | grep -oE 'Merge pull request #[0-9]+ from .*/(.*)' | awk '{print $NF}' | sed 's#^[^/]*/##')" >> $GITHUB_OUTPUT
+        echo "${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
 
     - name: Extract release name from branch name
       id: extract_release


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-119)

Fix the undeployment of the relevant helm release in the UAT environment when a PR is merged/closed.

Previously the name of the merged branch was taken from the commit message but this was dependent on the default commit message not being changed, which made it flaky. The new way doesn't rely on it and hence is more robust.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
